### PR TITLE
Give OscilloscopeDataCollector a default constructor

### DIFF
--- a/ntlab_opengl_realtime_visualization/RealtimeDataTransfer/OscilloscopeDataCollector.cpp
+++ b/ntlab_opengl_realtime_visualization/RealtimeDataTransfer/OscilloscopeDataCollector.cpp
@@ -27,7 +27,7 @@ SOFTWARE.
 
 namespace ntlab
 {
-    void OscilloscopeDataCollector::setChannels (int numChannels, juce::StringArray &channelNames)
+    void OscilloscopeDataCollector::setChannels (int numChannels, juce::StringArray channelNames)
     {
         this->numChannels = numChannels;
         this->channelNames = channelNames;

--- a/ntlab_opengl_realtime_visualization/RealtimeDataTransfer/OscilloscopeDataCollector.h
+++ b/ntlab_opengl_realtime_visualization/RealtimeDataTransfer/OscilloscopeDataCollector.h
@@ -56,10 +56,10 @@ namespace ntlab
         static const juce::String settingChannelNames;
 
         /**
-         * Specifiy an identifier extension to map the DataCollector to the corresponding target.
+         * Specify an identifier extension to map the DataCollector to the corresponding target.
          * The Identifier will automatically be prepended by "Oscilloscope"
          */
-        OscilloscopeDataCollector (const juce::String identifierExtension) : DataCollector ("Oscilloscope" + identifierExtension) {};
+        OscilloscopeDataCollector (const juce::String identifierExtension = "1") : DataCollector ("Oscilloscope" + identifierExtension) {};
 
         virtual ~OscilloscopeDataCollector () {};
 
@@ -70,7 +70,7 @@ namespace ntlab
          * @param numChannels    The new number of channels displayed by the oscilloscope
          * @param channelNames   An Array of size channelNames containing the names to be displayed for each channel
          */
-        void setChannels (int numChannels, juce::StringArray &channelNames);
+        void setChannels (int numChannels, juce::StringArray channelNames = juce::StringArray());
 
         /**
          * Set the timeframe viewed by the Oscilloscope. This impacts the number of samples collected before a GUI update.


### PR DESCRIPTION
Allow OscilloscopeDataCollector to be created with default values. Useful for use in a SharedResourcePointer. 
Fixed a typo. 