### PR TITLE
Replace SharedOpenGLContext with WindowOpenGLContext

### DIFF
--- a/ntlab_opengl_realtime_visualization/2DPlot/Plot2D.h
+++ b/ntlab_opengl_realtime_visualization/2DPlot/Plot2D.h
@@ -31,7 +31,7 @@ SOFTWARE.
 #include <juce_opengl/juce_opengl.h>
 #include "../Shader/LineShader.h"
 #include "../Utilities/Float2String.h"
-#include "../Utilities/SharedOpenGLContext.h"
+#include "../Utilities/WindowOpenGLContext.h"
 
 namespace ntlab
 {
@@ -69,7 +69,7 @@ namespace ntlab
         /**
          * Creates a plot2D instance with 0 data lines and an empty xValue range.
          */
-        Plot2D (bool updateAtFramerate);
+        Plot2D (bool updateAtFramerate, WindowOpenGLContext& glContext);
 
         /**
          * Creata a Plot2D instance with 0 data lines and the given xValue range. To get the number of x values created
@@ -79,7 +79,7 @@ namespace ntlab
          * @param xValueDelta       the spacing between the x values
          * @param xValueScaling     set to none for a linear x scale or to baseE for a logarithmic scaled x axis
          */
-        Plot2D (bool updateAtFramerate, juce::Range<float> xValueRange, float xValueDelta, LogScaling xValueScaling = LogScaling::none);
+        Plot2D (bool updateAtFramerate, WindowOpenGLContext& glContext, juce::Range<float> xValueRange, float xValueDelta, LogScaling xValueScaling = LogScaling::none);
 
         ~Plot2D();
 
@@ -236,6 +236,7 @@ namespace ntlab
     private:
 
         // OpenGL related member variables
+        WindowOpenGLContext&          windowOpenGLContext;
         juce::OpenGLContext&          openGLContext;
         std::unique_ptr<LineShader2D> lineShader;
         GLuint                        gridLineGLBuffer;
@@ -272,6 +273,7 @@ namespace ntlab
         int legendState = -1;
         bool drawLegendBorder = true;
         float legendBackgroundTransparency = 0.5f;
+
 
         // Some member functions needed to compute the visual aperance
         void getLineWidthRangePossibleForGPU();

--- a/ntlab_opengl_realtime_visualization/GUIComponents/OscilloscopeComponent.cpp
+++ b/ntlab_opengl_realtime_visualization/GUIComponents/OscilloscopeComponent.cpp
@@ -32,9 +32,9 @@ namespace ntlab
     const juce::Identifier OscilloscopeComponent::parameterTimeViewed       ("timeViewed");
     const juce::Identifier OscilloscopeComponent::parameterEnableTriggering ("enableTriggering");
 
-    OscilloscopeComponent::OscilloscopeComponent (const juce::String identifierExtension, juce::UndoManager* undoManager)
+    OscilloscopeComponent::OscilloscopeComponent (const juce::String identifierExtension, WindowOpenGLContext& windowOpenGlContext, juce::UndoManager* undoManager)
     : VisualizationTarget ("Oscilloscope" + identifierExtension, undoManager),
-      Plot2D (true)
+      Plot2D (true, windowOpenGlContext)
     {
         valueTree.addListener (this);
         valueTree.setProperty (parameterGainLinear,       1.0,   undoManager);

--- a/ntlab_opengl_realtime_visualization/GUIComponents/OscilloscopeComponent.h
+++ b/ntlab_opengl_realtime_visualization/GUIComponents/OscilloscopeComponent.h
@@ -55,7 +55,7 @@ namespace ntlab
          * The Identifier will automatically be prepended by "Oscilloscope". The optional undo manager can
          * be passed to enable undo functionality for the parameters held by the ValueTree.
          */
-        OscilloscopeComponent (const juce::String identifierExtension, juce::UndoManager* undoManager = nullptr);
+        OscilloscopeComponent (const juce::String identifierExtension, WindowOpenGLContext& windowOpenGlContext, juce::UndoManager* undoManager = nullptr);
 
         ~OscilloscopeComponent();
 

--- a/ntlab_opengl_realtime_visualization/GUIComponents/SpectralAnalyzerComponent.cpp
+++ b/ntlab_opengl_realtime_visualization/GUIComponents/SpectralAnalyzerComponent.cpp
@@ -36,9 +36,9 @@ namespace ntlab
     const juce::Identifier SpectralAnalyzerComponent::parameterMagnitudeLinearDB       ("magnitudeLinearDB");
     const juce::Identifier SpectralAnalyzerComponent::parameterFrequencyLinearLog      ("frequencyLinearLog");
 
-    SpectralAnalyzerComponent::SpectralAnalyzerComponent (const juce::String identifierExtension, juce::UndoManager *undoManager)
+    SpectralAnalyzerComponent::SpectralAnalyzerComponent (const juce::String identifierExtension, WindowOpenGLContext& windowOpenGlContext, juce::UndoManager *undoManager)
     : VisualizationTarget ("SpectralAnalyzer" + identifierExtension, undoManager),
-      Plot2D (true)
+      Plot2D (true, windowOpenGlContext)
     {
         // create value tree properties
         valueTree.addListener (this);

--- a/ntlab_opengl_realtime_visualization/GUIComponents/SpectralAnalyzerComponent.h
+++ b/ntlab_opengl_realtime_visualization/GUIComponents/SpectralAnalyzerComponent.h
@@ -66,7 +66,7 @@ namespace ntlab
          * The Identifier will automatically be prepended by "SpectralAnalyzer". The optional undo manager can
          * be passed to enable undo functionality for the parameters held by the ValueTree.
          */
-        SpectralAnalyzerComponent (const juce::String identifierExtension, juce::UndoManager* undoManager = nullptr);
+        SpectralAnalyzerComponent (const juce::String identifierExtension, WindowOpenGLContext& windowOpenGlContext, juce::UndoManager* undoManager = nullptr);
 
         ~SpectralAnalyzerComponent();
 

--- a/ntlab_opengl_realtime_visualization/Utilities/WindowOpenGLContext.h
+++ b/ntlab_opengl_realtime_visualization/Utilities/WindowOpenGLContext.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
 MIT License
 
@@ -22,18 +23,17 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-#pragma once
 
 #include <juce_opengl/juce_opengl.h>
 
 namespace ntlab
 {
-    class SharedOpenGLContext : public juce::DeletedAtShutdown, private juce::OpenGLRenderer
+    class WindowOpenGLContext :  private juce::OpenGLRenderer
     {
     public:
-        SharedOpenGLContext();
+        WindowOpenGLContext();
 
-        ~SharedOpenGLContext();
+        ~WindowOpenGLContext();
 
         void setTopLevelParentComponent (juce::Component& topLevelComponent);
 
@@ -51,7 +51,6 @@ namespace ntlab
 
         juce::OpenGLContext openGLContext;
 
-        JUCE_DECLARE_SINGLETON (SharedOpenGLContext, false)
     private:
         juce::Component* topLevelComponent = nullptr;
 
@@ -66,6 +65,6 @@ namespace ntlab
         void renderOpenGL() override;
         void openGLContextClosing() override;
 
-        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (SharedOpenGLContext)
+        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (WindowOpenGLContext)
     };
 }

--- a/ntlab_opengl_realtime_visualization/ntlab_opengl_realtime_visualization.cpp
+++ b/ntlab_opengl_realtime_visualization/ntlab_opengl_realtime_visualization.cpp
@@ -29,7 +29,7 @@ SOFTWARE.
 
 #if JUCE_MODULE_AVAILABLE_juce_opengl
 
-#include "Utilities/SharedOpenGLContext.cpp"
+#include "Utilities/WindowOpenGLContext.cpp"
 
 #include "2DPlot/Plot2D.cpp"
 

--- a/ntlab_opengl_realtime_visualization/ntlab_opengl_realtime_visualization.h
+++ b/ntlab_opengl_realtime_visualization/ntlab_opengl_realtime_visualization.h
@@ -63,7 +63,7 @@ SOFTWARE.
 // running on a system with any GUI
 #if JUCE_MODULE_AVAILABLE_juce_opengl
 
-#include "Utilities/SharedOpenGLContext.h"
+#include "Utilities/WindowOpenGLContext.h"
 
 #include "2DPlot/Plot2D.h"
 


### PR DESCRIPTION
For multi-window apps, each window requires its own `OpenGLContext`. This PR removes the singleton `SharedOpenGLContext` and renames it `WindowOpenGLContext`. See #4. 

Wherever a "shared" context is required, it is declared as `SharedResourcePointer< WindowOpenGLContext>` which makes it in effect a singleton. 